### PR TITLE
Update memory budget, Knobs

### DIFF
--- a/asterixdb/asterix-app/src/test/resources/cc.conf
+++ b/asterixdb/asterix-app/src/test/resources/cc.conf
@@ -19,17 +19,8 @@
 txn.log.dir=target/tmp/asterix_nc1/txnlog
 core.dump.dir=target/tmp/asterix_nc1/coredump
 iodevices=target/tmp/asterix_nc1/iodevice1,
-iodevices=../asterix-server/target/tmp/asterix_nc1/iodevice2
 nc.api.port=19004
 #jvm.args=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006
-
-[nc/asterix_nc2]
-ncservice.port=9091
-txn.log.dir=target/tmp/asterix_nc2/txnlog
-core.dump.dir=target/tmp/asterix_nc2/coredump
-iodevices=target/tmp/asterix_nc2/iodevice1,../asterix-server/target/tmp/asterix_nc2/iodevice2
-nc.api.port=19005
-#jvm.args=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5007
 
 [nc]
 credential.file=src/test/resources/security/passwd

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/DeallocatableFramePool.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/DeallocatableFramePool.java
@@ -28,10 +28,10 @@ import org.apache.hyracks.api.exceptions.HyracksDataException;
 
 public class DeallocatableFramePool implements IDeallocatableFramePool {
 
-    private final IHyracksFrameMgrContext ctx;
-    private final int memBudget;
-    private int allocated;
-    private LinkedList<ByteBuffer> buffers;
+    protected final IHyracksFrameMgrContext ctx;
+    protected int memBudget;
+    protected int allocated;
+    protected LinkedList<ByteBuffer> buffers;
 
     public DeallocatableFramePool(IHyracksFrameMgrContext ctx, int memBudgetInBytes) {
         this.ctx = ctx;
@@ -107,6 +107,11 @@ public class DeallocatableFramePool implements IDeallocatableFramePool {
         } else {
             buffers.add(buffer);
         }
+    }
+
+    @Override
+    public boolean updateMemoryBudget(int newBudget) {
+        return false;
     }
 
     @Override

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/DeallocatableFramePoolDynamicBudget.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/DeallocatableFramePoolDynamicBudget.java
@@ -1,12 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.hyracks.dataflow.std.buffermanager;
-
-import org.apache.hyracks.api.context.IHyracksFrameMgrContext;
 
 import java.nio.ByteBuffer;
 
-public class DeallocatableFramePoolDynamicBudget extends DeallocatableFramePool{
+import org.apache.hyracks.api.context.IHyracksFrameMgrContext;
+
+public class DeallocatableFramePoolDynamicBudget extends DeallocatableFramePool {
 
     int desiredBuffer = Integer.MAX_VALUE;
+
     public DeallocatableFramePoolDynamicBudget(IHyracksFrameMgrContext ctx, int memBudgetInBytes) {
         super(ctx, memBudgetInBytes);
     }
@@ -17,7 +36,7 @@ public class DeallocatableFramePoolDynamicBudget extends DeallocatableFramePool{
             // simply deallocate the Big Object frame
             ctx.deallocateFrames(buffer.capacity());
             int framesReleased = buffer.capacity();
-            if(desiredBuffer < allocated){
+            if (desiredBuffer < allocated) {
                 memBudget = memBudget - framesReleased;
                 memBudget = memBudget < desiredBuffer ? desiredBuffer : memBudget;
             }
@@ -28,9 +47,9 @@ public class DeallocatableFramePoolDynamicBudget extends DeallocatableFramePool{
     }
 
     @Override
-    public boolean updateMemoryBudget(int newBudget){
+    public boolean updateMemoryBudget(int newBudget) {
         desiredBuffer = newBudget * ctx.getInitialFrameSize();
-        if(this.allocated < desiredBuffer){
+        if (this.allocated < desiredBuffer) {
             this.memBudget = desiredBuffer; //Simply Update Memory Budget
             return true;
         }

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/DeallocatableFramePoolDynamicBudget.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/DeallocatableFramePoolDynamicBudget.java
@@ -1,0 +1,40 @@
+package org.apache.hyracks.dataflow.std.buffermanager;
+
+import org.apache.hyracks.api.context.IHyracksFrameMgrContext;
+
+import java.nio.ByteBuffer;
+
+public class DeallocatableFramePoolDynamicBudget extends DeallocatableFramePool{
+
+    int desiredBuffer = Integer.MAX_VALUE;
+    public DeallocatableFramePoolDynamicBudget(IHyracksFrameMgrContext ctx, int memBudgetInBytes) {
+        super(ctx, memBudgetInBytes);
+    }
+
+    @Override
+    public void deAllocateBuffer(ByteBuffer buffer) {
+        if (buffer.capacity() != ctx.getInitialFrameSize() || desiredBuffer < allocated) {
+            // simply deallocate the Big Object frame
+            ctx.deallocateFrames(buffer.capacity());
+            int framesReleased = buffer.capacity();
+            if(desiredBuffer < allocated){
+                memBudget = memBudget - framesReleased;
+                memBudget = memBudget < desiredBuffer ? desiredBuffer : memBudget;
+            }
+            allocated -= framesReleased;
+        } else {
+            buffers.add(buffer);
+        }
+    }
+
+    @Override
+    public boolean updateMemoryBudget(int newBudget){
+        desiredBuffer = newBudget * ctx.getInitialFrameSize();
+        if(this.allocated < newBudget){
+            this.memBudget = desiredBuffer; //Simply Update Memory Budget
+            return true;
+        }
+        return false; //There are more alocated Frames then the new Budget.
+    }
+
+}

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/DeallocatableFramePoolDynamicBudget.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/DeallocatableFramePoolDynamicBudget.java
@@ -30,7 +30,7 @@ public class DeallocatableFramePoolDynamicBudget extends DeallocatableFramePool{
     @Override
     public boolean updateMemoryBudget(int newBudget){
         desiredBuffer = newBudget * ctx.getInitialFrameSize();
-        if(this.allocated < newBudget){
+        if(this.allocated < desiredBuffer){
             this.memBudget = desiredBuffer; //Simply Update Memory Budget
             return true;
         }

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/IDeallocatableFramePool.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/IDeallocatableFramePool.java
@@ -25,4 +25,6 @@ public interface IDeallocatableFramePool extends IFramePool {
 
     void deAllocateBuffer(ByteBuffer buffer);
 
+    boolean updateMemoryBudget(int newBudget);
+
 }

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/IPartitionedTupleBufferManager.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/IPartitionedTupleBufferManager.java
@@ -131,4 +131,6 @@ public interface IPartitionedTupleBufferManager {
     void clearPartition(int partition) throws HyracksDataException;
 
     IPartitionedMemoryConstrain getConstrain();
+
+    boolean updateMemoryBudget(int newBudget);
 }

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/VPartitionTupleBufferManager.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/VPartitionTupleBufferManager.java
@@ -312,7 +312,7 @@ public class VPartitionTupleBufferManager implements IPartitionedTupleBufferMana
     }
 
     @Override
-    public boolean updateMemoryBudget(int newBudget){
+    public boolean updateMemoryBudget(int newBudget) {
         return framePool.updateMemoryBudget(newBudget);
     }
 

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/VPartitionTupleBufferManager.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/VPartitionTupleBufferManager.java
@@ -311,4 +311,9 @@ public class VPartitionTupleBufferManager implements IPartitionedTupleBufferMana
         return constrain;
     }
 
+    @Override
+    public boolean updateMemoryBudget(int newBudget){
+        return framePool.updateMemoryBudget(newBudget);
+    }
+
 }

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/HybridHashJoinUtil.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/HybridHashJoinUtil.java
@@ -37,11 +37,11 @@ public class HybridHashJoinUtil {
      * Prints out the detailed information for partitions: in-memory and spilled partitions.
      * This method exists for a debug purpose.
      */
-    public String printPartitionInfo(BitSet spilledStatus, SIDE whichSide, int numOfPartitions, int[] probePSizeInTups,
+    public static String printPartitionInfo(BitSet spilledStatus, SIDE whichSide, int numOfPartitions, int[] probePSizeInTups,
             int[] buildPSizeInTups, RunFileWriter[] probeRFWriters, RunFileWriter[] buildRFWriters,
             IPartitionedTupleBufferManager bufferManager) {
         StringBuilder buf = new StringBuilder();
-        buf.append(">>> " + this + " " + Thread.currentThread().getId() + " printInfo():" + "\n");
+        buf.append(">>> "  + " " + Thread.currentThread().getId() + " printInfo():" + "\n");
         if (whichSide == SIDE.BUILD) {
             buf.append("BUILD side" + "\n");
         } else {

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/IOptimizedHybridHashJoin.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/IOptimizedHybridHashJoin.java
@@ -1,13 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.hyracks.dataflow.std.join;
+
+import java.nio.ByteBuffer;
+import java.util.BitSet;
 
 import org.apache.hyracks.api.comm.IFrameWriter;
 import org.apache.hyracks.api.dataflow.value.ITuplePairComparator;
 import org.apache.hyracks.api.exceptions.HyracksDataException;
 import org.apache.hyracks.api.job.profiling.IOperatorStats;
 import org.apache.hyracks.dataflow.common.io.RunFileReader;
-
-import java.nio.ByteBuffer;
-import java.util.BitSet;
 
 public interface IOptimizedHybridHashJoin {
     void initBuild() throws HyracksDataException;

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/IOptimizedHybridHashJoin.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/IOptimizedHybridHashJoin.java
@@ -44,7 +44,6 @@ public interface IOptimizedHybridHashJoin {
     void initProbe(ITuplePairComparator comparator);
 
     void probe(ByteBuffer buffer, IFrameWriter writer) throws HyracksDataException;
-
     void completeProbe(IFrameWriter writer) throws HyracksDataException;
 
     void releaseResource() throws HyracksDataException;

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/IOptimizedHybridHashJoin.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/IOptimizedHybridHashJoin.java
@@ -1,0 +1,52 @@
+package org.apache.hyracks.dataflow.std.join;
+
+import org.apache.hyracks.api.comm.IFrameWriter;
+import org.apache.hyracks.api.dataflow.value.ITuplePairComparator;
+import org.apache.hyracks.api.exceptions.HyracksDataException;
+import org.apache.hyracks.api.job.profiling.IOperatorStats;
+import org.apache.hyracks.dataflow.common.io.RunFileReader;
+
+import java.nio.ByteBuffer;
+import java.util.BitSet;
+
+public interface IOptimizedHybridHashJoin {
+    void initBuild() throws HyracksDataException;
+
+    void build(ByteBuffer buffer) throws HyracksDataException;
+
+    void closeBuild() throws HyracksDataException;
+
+    void clearBuildTempFiles() throws HyracksDataException;
+
+    void clearProbeTempFiles() throws HyracksDataException;
+
+    void fail() throws HyracksDataException;
+
+    void initProbe(ITuplePairComparator comparator);
+
+    void probe(ByteBuffer buffer, IFrameWriter writer) throws HyracksDataException;
+
+    void completeProbe(IFrameWriter writer) throws HyracksDataException;
+
+    void releaseResource() throws HyracksDataException;
+
+    RunFileReader getBuildRFReader(int pid) throws HyracksDataException;
+
+    int getBuildPartitionSizeInTup(int pid);
+
+    RunFileReader getProbeRFReader(int pid) throws HyracksDataException;
+
+    int getProbePartitionSizeInTup(int pid);
+
+    int getMaxBuildPartitionSize();
+
+    int getMaxProbePartitionSize();
+
+    BitSet getPartitionStatus();
+
+    int getPartitionSize(int pid);
+
+    void setIsReversed(boolean reversed);
+
+    void setOperatorStats(IOperatorStats stats);
+}

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/InMemoryHashJoin.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/InMemoryHashJoin.java
@@ -221,7 +221,6 @@ public class InMemoryHashJoin {
         table.close();
     }
 
-
     private void appendToResult(int probeSidetIx, int buildSidetIx, IFrameWriter writer) throws HyracksDataException {
         if (reverseOutputOrder) {
             FrameUtils.appendConcatToWriter(writer, appender, accessorBuild, buildSidetIx, accessorProbe, probeSidetIx);

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/InMemoryHashJoin.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/InMemoryHashJoin.java
@@ -55,7 +55,7 @@ public class InMemoryHashJoin {
     private ITuplePairComparator tpComparator;
     private final boolean isLeftOuter;
     private final ArrayTupleBuilder missingTupleBuild;
-    private final ISerializableTable table;
+    private ISerializableTable table;
     private final TuplePointer storedTuplePointer;
     private final boolean reverseOutputOrder; //Should we reverse the order of tuples, we are writing in output
     private final TupleInFrameListAccessor tupleAccessor;
@@ -220,6 +220,7 @@ public class InMemoryHashJoin {
     public void closeTable() throws HyracksDataException {
         table.close();
     }
+
 
     private void appendToResult(int probeSidetIx, int buildSidetIx, IFrameWriter writer) throws HyracksDataException {
         if (reverseOutputOrder) {

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/MemoryContentionResponsiveHHJ.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/MemoryContentionResponsiveHHJ.java
@@ -1,44 +1,97 @@
-package org.apache.hyracks.dataflow.std.join;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-import org.apache.http.util.Asserts;
-import org.apache.hyracks.api.comm.IFrameWriter;
-import org.apache.hyracks.api.comm.VSizeFrame;
-import org.apache.hyracks.api.context.IHyracksJobletContext;
-import org.apache.hyracks.api.dataflow.value.*;
-import org.apache.hyracks.api.exceptions.HyracksDataException;
-import org.apache.hyracks.dataflow.common.comm.io.FrameTupleAccessor;
-import org.apache.hyracks.dataflow.common.io.RunFileReader;
-import org.apache.hyracks.dataflow.common.io.RunFileWriter;
-import org.apache.hyracks.dataflow.std.buffermanager.*;
-import org.apache.hyracks.dataflow.std.structures.ISerializableTable;
-import org.apache.hyracks.dataflow.std.structures.SerializableHashTable;
+package org.apache.hyracks.dataflow.std.join;
 
 import java.nio.ByteBuffer;
 import java.util.BitSet;
 import java.util.Random;
 
+import org.apache.hyracks.api.comm.IFrameWriter;
+import org.apache.hyracks.api.comm.VSizeFrame;
+import org.apache.hyracks.api.context.IHyracksJobletContext;
+import org.apache.hyracks.api.dataflow.value.IMissingWriterFactory;
+import org.apache.hyracks.api.dataflow.value.IPredicateEvaluator;
+import org.apache.hyracks.api.dataflow.value.ITuplePairComparator;
+import org.apache.hyracks.api.dataflow.value.ITuplePartitionComputer;
+import org.apache.hyracks.api.dataflow.value.RecordDescriptor;
+import org.apache.hyracks.api.exceptions.HyracksDataException;
+import org.apache.hyracks.dataflow.common.comm.io.FrameTupleAccessor;
+import org.apache.hyracks.dataflow.common.io.RunFileReader;
+import org.apache.hyracks.dataflow.common.io.RunFileWriter;
+import org.apache.hyracks.dataflow.std.buffermanager.DeallocatableFramePoolDynamicBudget;
+import org.apache.hyracks.dataflow.std.buffermanager.IDeallocatableFramePool;
+import org.apache.hyracks.dataflow.std.buffermanager.VPartitionTupleBufferManager;
+import org.apache.hyracks.dataflow.std.structures.SerializableHashTable;
+
 public class MemoryContentionResponsiveHHJ extends OptimizedHybridHashJoin {
+    /**Frame Count**/
     private int processedFrames = 0;
-    private int frameInterval = 10;
-    private boolean eventBased = false;
+    /**@todo: This is used to set margins for the memory update, it should not go to production code.**/
     private int originalBudget;
-    private Random random = new Random();
+    private Random random;
     ITuplePairComparator comparator;
     BitSet inconsistentStatus;
 
-    //Knobs
+    //region Knobs
+    /**
+     * Interval of frames to call the memory update methods
+     **/
+    private int frameInterval = 10;
+    /**
+     * If set as true a memory update will happen before spilling a partition during Build Phase
+     **/
+    private boolean eventBased = true;
+    /**
+     * Enables memory expansion during Build phase
+     **/
     private boolean memoryExpansionBuild = true;
+    /**
+     * Enables memory contention during Build phase
+     **/
     private boolean memoryContentionBuild = true;
-    private boolean memoryExpansionProbe = false;
+    /**
+     * Enables memory expansion during Probe phase
+     **/
+    private boolean memoryExpansionProbe = true;
+    /**
+     * Enables memory expansion during Probe phase
+     **/
     private boolean memoryContentionProbe = true;
+    /**
+     * Enables probing inconsistent partitons before completing the build phase
+     **/
     private boolean probeInconsistentThisRound = true;
 
-    public MemoryContentionResponsiveHHJ(IHyracksJobletContext jobletCtx, int memSizeInFrames, int numOfPartitions, String probeRelName, String buildRelName, RecordDescriptor probeRd, RecordDescriptor buildRd, ITuplePartitionComputer probeHpc, ITuplePartitionComputer buildHpc, IPredicateEvaluator probePredEval, IPredicateEvaluator buildPredEval, boolean isLeftOuter, IMissingWriterFactory[] nullWriterFactories1) {
-        super(jobletCtx, memSizeInFrames, numOfPartitions, probeRelName, buildRelName, probeRd, buildRd, probeHpc, buildHpc, probePredEval, buildPredEval, isLeftOuter, nullWriterFactories1);
+    //endregion
+    public MemoryContentionResponsiveHHJ(IHyracksJobletContext jobletCtx, int memSizeInFrames, int numOfPartitions,
+                                         String probeRelName, String buildRelName, RecordDescriptor probeRd, RecordDescriptor buildRd,
+                                         ITuplePartitionComputer probeHpc, ITuplePartitionComputer buildHpc, IPredicateEvaluator probePredEval,
+                                         IPredicateEvaluator buildPredEval, boolean isLeftOuter, IMissingWriterFactory[] nullWriterFactories1) {
+        super(jobletCtx, memSizeInFrames, numOfPartitions, probeRelName, buildRelName, probeRd, buildRd, probeHpc,
+                buildHpc, probePredEval, buildPredEval, isLeftOuter, nullWriterFactories1);
         originalBudget = memSizeInFrames;
         inconsistentStatus = new BitSet(numOfPartitions);
+        random = new Random(-933090634); //This random seed is generating the Hash Table insertion Failure for my test query.
     }
 
+    //region BUILD
     public void initBuild() throws HyracksDataException {
         IDeallocatableFramePool framePool =
                 new DeallocatableFramePoolDynamicBudget(jobletCtx, memSizeInFrames * jobletCtx.getInitialFrameSize());
@@ -50,14 +103,6 @@ public class MemoryContentionResponsiveHHJ extends OptimizedHybridHashJoin {
             updateMemoryBudgetBuildPhase();
         }
         super.build(buffer);
-        processedFrames++;
-    }
-
-    public void probe(ByteBuffer buffer, IFrameWriter writer) throws HyracksDataException {
-        if (frameInterval > 0 &&processedFrames % frameInterval == 0) {
-            updateMemoryBudgetProbePhase();
-        }
-        super.probe(buffer, writer);
         processedFrames++;
     }
 
@@ -77,7 +122,7 @@ public class MemoryContentionResponsiveHHJ extends OptimizedHybridHashJoin {
         if (newBudgetInFrames >= memSizeInFrames && memoryExpansionBuild) {
             bufferManager.updateMemoryBudget(newBudgetInFrames);
             memSizeInFrames = newBudgetInFrames;
-        } else if(memoryContentionBuild){
+        } else if (memoryContentionBuild) {
             while (!bufferManager.updateMemoryBudget(newBudgetInFrames)) {
                 int victimPartition = spillPolicy.findSpilledPartitionWithMaxMemoryUsage();
                 if (victimPartition < 0) {
@@ -87,7 +132,6 @@ public class MemoryContentionResponsiveHHJ extends OptimizedHybridHashJoin {
                     break;
                 }
                 int framesToRelease = bufferManager.getPhysicalSize(victimPartition) / jobletCtx.getInitialFrameSize();
-                LOGGER.info(String.format("Spill Due to Memory Contention Partition:%d", victimPartition));
                 spillPartition(victimPartition);
                 memSizeInFrames -= framesToRelease;
                 memSizeInFrames = memSizeInFrames <= newBudgetInFrames ? newBudgetInFrames : memSizeInFrames;
@@ -95,118 +139,13 @@ public class MemoryContentionResponsiveHHJ extends OptimizedHybridHashJoin {
         }
     }
 
-    private void updateMemoryBudgetProbePhase() throws HyracksDataException {
-        int newBudgetInFrames = random.nextInt(originalBudget) + this.originalBudget;
-        if (newBudgetInFrames > memSizeInFrames && memoryExpansionProbe) { //Memory Expansion Scenario
-            if (bufferManager.updateMemoryBudget(newBudgetInFrames)) {
-                memSizeInFrames = newBudgetInFrames;
-            }
-            memoryExpansionProbe();
-        }
-        else if (memoryContentionProbe){
-            memoryContentionPorbe(newBudgetInFrames);
-        }
-    }
-
-    private void memoryContentionPorbe(int newBudgetInFrames) throws HyracksDataException {
-        while (!bufferManager.updateMemoryBudget(newBudgetInFrames)) {
-            int victimPartition = spillPolicy.findInMemPartitionWithMaxMemoryUsage();
-            if (victimPartition < 0) {
-                break;
-            }
-            int framesToRelease = bufferManager.getPhysicalSize(victimPartition) / jobletCtx.getInitialFrameSize();
-            LOGGER.info(String.format("Spill Due to Memory Contention PROBE Partition:%d", victimPartition));
-            spillPartition(victimPartition);
-            memSizeInFrames -= framesToRelease;
-            memSizeInFrames = memSizeInFrames <= newBudgetInFrames ? newBudgetInFrames : memSizeInFrames;
-        }
-    }
-
-    private void memoryExpansionProbe() throws HyracksDataException {
-        freeSpace fs = calculateFreeSpace();
-        int partitionToReload = selectAPartitionToReload(fs.freeSpace, 0, fs.tuplesInMemory);
-        int inconsistentPartitions = inconsistentStatus.cardinality();
-        while (partitionToReload >= 0) {
-            if (partitionToReload >= 0) {
-                //Flush Tuples that are in the probe output buffer of the partition that will be reloaded to disk.
-                //Before reloading Build Tuples into memory.
-                //Clear the outputbuffer later
-                if (bufferManager.getNumTuples(partitionToReload) > 0) {
-                    LOGGER.info(String.format("Probe later: %d",bufferManager.getNumTuples(partitionToReload) ));
-                    RunFileWriter probeRFWriter =
-                            getSpillWriterOrCreateNewOneIfNotExist(probeRFWriters, probeRelName, partitionToReload);
-                    bufferManager.flushPartition(partitionToReload, probeRFWriter);
-                    LOGGER.info(String.format("Probe Partition %d Size:%d",partitionToReload,probeRFWriter.getFileSize()));
-                    bufferManager.clearPartition(partitionToReload);
-                }
-                //Reload Build Tuples from disk into memory.
-                RunFileWriter buildRFWriter =
-                        getSpillWriterOrCreateNewOneIfNotExist(buildRFWriters, buildRelName, partitionToReload);
-                if(loadSpilledPartitionToMem(partitionToReload, buildRFWriter)){
-                    inconsistentStatus.set(partitionToReload, true);
-                }
-            }
-            fs = calculateFreeSpace();
-            partitionToReload = selectAPartitionToReload(fs.freeSpace, 0, fs.tuplesInMemory);
-        }
-        rebuildHashTable();
-    }
-
-    @Override
-    public RunFileReader getProbeRFReader(int pid) throws HyracksDataException {
-        return probeRFWriters[pid] == null ? null : probeRFWriters[pid].createReader();
-    }
-    protected boolean loadSpilledPartitionToMem(int pid, RunFileWriter wr) throws HyracksDataException {
-        RunFileReader r = wr.createReader();
-            r.open();
-            if (reloadBuffer == null) {
-                reloadBuffer = new VSizeFrame(jobletCtx);
-            }
-            while (r.nextFrame(reloadBuffer)) {
-                if (stats != null) {
-                    //TODO: be certain it is the case this is actually eagerly read
-                    stats.getBytesRead().update(reloadBuffer.getBuffer().limit());
-                }
-                accessorBuild.reset(reloadBuffer.getBuffer());
-                for (int tid = 0; tid < accessorBuild.getTupleCount(); tid++) {
-                    if (!bufferManager.insertTuple(pid, accessorBuild, tid, tempPtr)) {
-                        // for some reason (e.g. fragmentation) if inserting fails, we need to clear the occupied frames
-                        bufferManager.clearPartition(pid);
-                        return false;
-                    }
-                }
-            }
-            // Closes and deletes the run file if it is already loaded into memory.
-        spilledStatus.set(pid, false);
-        buildRFWriters[pid] = null;
-        return true;
-    }
-
-    private void rebuildHashTable() throws HyracksDataException {
-        freeSpace fs = calculateFreeSpace();
-        ISerializableTable table2 = new SerializableHashTable(fs.tuplesInMemory, jobletCtx, bufferManagerForHashTable);
-        this.inMemJoiner = new InMemoryHashJoin(jobletCtx, new FrameTupleAccessor(probeRd), probeHpc,
-                new FrameTupleAccessor(buildRd), buildRd, buildHpc, isLeftOuter, nonMatchWriters, table2, isReversed,
-                bufferManagerForHashTable);
-        inMemJoiner.setComparator(this.comparator);
-        bufferManager.setConstrain(VPartitionTupleBufferManager.NO_CONSTRAIN);
-        buildHashTable();
-    }
-
-    @Override
-    public void initProbe(ITuplePairComparator comparator) {
-        this.comparator = comparator;
-        probePSizeInTups = new int[numOfPartitions];
-        inMemJoiner.setComparator(comparator);
-        bufferManager.setConstrain(VPartitionTupleBufferManager.NO_CONSTRAIN);
-    }
-
-    @Override
-    public BitSet getPartitionStatus() {
-        inconsistentStatus.or(spilledStatus);
-        return inconsistentStatus;
-    }
-
+    /**
+     * Override the original method, if the knobe ("eventBased") is set as true the memory budget update is called in case of tuple insertion failed.
+     *
+     * @param tid Tuple Id
+     * @param pid Partition Id
+     * @throws HyracksDataException
+     */
     protected void processTupleBuildPhase(int tid, int pid) throws HyracksDataException {
         //If event Based Memory adaption is on and the first insert try fails updates the memory budget.
         if (eventBased) {
@@ -218,36 +157,261 @@ public class MemoryContentionResponsiveHHJ extends OptimizedHybridHashJoin {
             super.processTupleBuildPhaseInternal(tid, pid);
         }
     }
+    //endregion
+
+    //region PROBE
+    public void probe(ByteBuffer buffer, IFrameWriter writer) throws HyracksDataException {
+        if (frameInterval > 0 && processedFrames % frameInterval == 0) {
+            updateMemoryBudgetProbePhase();
+        }
+        super.probe(buffer, writer);
+        processedFrames++;
+    }
+
+    private void updateMemoryBudgetProbePhase() throws HyracksDataException {
+        int newBudgetInFrames = random.nextInt(originalBudget) + this.originalBudget;
+        if (newBudgetInFrames > memSizeInFrames && memoryExpansionProbe) { //Memory Expansion Scenario
+            if (bufferManager.updateMemoryBudget(newBudgetInFrames)) {
+                memSizeInFrames = newBudgetInFrames;
+            }
+            memoryExpansionProbe();
+        } else if (memoryContentionProbe) {
+            memoryContentionPorbe(newBudgetInFrames);
+        }
+    }
+
+    /**
+     * Spill memory resident partition to disk during probe.
+     *
+     * @param newBudgetInFrames
+     * @throws HyracksDataException
+     */
+    private void memoryContentionPorbe(int newBudgetInFrames) throws HyracksDataException {
+        while (!bufferManager.updateMemoryBudget(newBudgetInFrames)) {
+            int victimPartition = spillPolicy.findInMemPartitionWithMaxMemoryUsage();
+            if (victimPartition < 0) {
+                break;
+            }
+            int framesToRelease = bufferManager.getPhysicalSize(victimPartition) / jobletCtx.getInitialFrameSize();
+            spillPartition(victimPartition);
+            memSizeInFrames -= framesToRelease;
+            memSizeInFrames = memSizeInFrames <= newBudgetInFrames ? newBudgetInFrames : memSizeInFrames;
+        }
+    }
+
+    /**
+     * Reload spilled partitions into memory and then call the to rebuild the Hash Table.
+     * <ul>
+     *     <li>Select a partition to Reload (this can be optimized)</li>
+     *     <li>Spill buffer frames used as output frames for the Probe Partition to disk</li>
+     *     <li>Clears the Partition's buffer</li>
+     *     <li>Reload build partition's tuples into memory./<li>
+     *     <li>Rebuild Hash Table</li>
+     * </ul>
+     *
+     * @throws HyracksDataException
+     */
+    private void memoryExpansionProbe() throws HyracksDataException {
+        freeSpace fs = calculateFreeSpace();
+        boolean shouldRebuildHashTable = false;
+        int partitionToReload = selectAPartitionToReloadProbe(fs.freeSpace, fs.tuplesInMemory);
+        while (partitionToReload >= 0) {
+            long hashTableSizeAfter = SerializableHashTable.getExpectedTableByteSize(
+                    fs.tuplesInMemory + getBuildPartitionSizeInTup(partitionToReload), jobletCtx.getInitialFrameSize());
+            LOGGER.info(String.format("Partition Size: %d | Hash Size After Rebuild: %d | Free Space: %d",
+                    getPartitionSize(partitionToReload), hashTableSizeAfter, fs.freeSpace));
+            //Flush Tuples that are in the probe output buffer of the partition that will be reloaded to disk.
+            //Before reloading Build Tuples into memory.
+            //Clear the outputbuffer later
+            int tuplesToProbeLater = bufferManager.getNumTuples(partitionToReload);
+            if (tuplesToProbeLater > 0) {
+                RunFileWriter probeRFWriter =
+                        getSpillWriterOrCreateNewOneIfNotExist(probeRFWriters, probeRelName, partitionToReload);
+                bufferManager.flushPartition(partitionToReload, probeRFWriter);
+                bufferManager.clearPartition(partitionToReload);
+                LOGGER.info(String.format("Probe Partition %d later | Number of tuples: %d | file size: %d Bytes",
+                        partitionToReload, tuplesToProbeLater, probeRFWriter.getFileSize()));
+            }
+            //Reload Build Tuples from disk into memory.
+            RunFileWriter buildRFWriter =
+                    getSpillWriterOrCreateNewOneIfNotExist(buildRFWriters, buildRelName, partitionToReload);
+            if (loadSpilledPartitionToMem(partitionToReload, buildRFWriter)) {
+                inconsistentStatus.set(partitionToReload, true);
+                shouldRebuildHashTable = true;
+            }
+
+            fs = calculateFreeSpace();
+            partitionToReload = selectAPartitionToReload(fs.freeSpace, 0, fs.tuplesInMemory);
+        }
+        if (shouldRebuildHashTable) {
+            rebuildHashTable();
+        }
+    }
+
+    /**
+     * Finds a partition that can fit in the left over memory.
+     *
+     * @param freeSpace     current free space
+     * @param inMemTupCount number of tuples currently in memory
+     * @return partition id of selected partition to reload
+     */
+    protected int selectAPartitionToReloadProbe(long freeSpace, int inMemTupCount) {
+        int frameSize = jobletCtx.getInitialFrameSize();
+        // Add one frame to freeSpace to consider the one frame reserved for the spilled partition
+        long totalFreeSpace = freeSpace + frameSize;
+        if (totalFreeSpace > 0) {
+            for (int i = spilledStatus.nextSetBit(0); i >= 0 && i < numOfPartitions; i =
+                    spilledStatus.nextSetBit(i + 1)) {
+                int spilledTupleCount = buildPSizeInTups[i];
+                // Expected hash table size increase after reloading this partition
+                long originalHashTableSize = table.getCurrentByteSize();
+                totalFreeSpace += originalHashTableSize;
+                long expectedHashTableSize =
+                        SerializableHashTable.getExpectedTableByteSize(inMemTupCount + spilledTupleCount, frameSize);
+                if (totalFreeSpace >= buildRFWriters[i].getFileSize() + expectedHashTableSize) {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Creates a file reader that will not be deleted after closing.
+     *
+     * @param pid
+     * @return
+     * @throws HyracksDataException
+     */
+    @Override
+    public RunFileReader getProbeRFReader(int pid) throws HyracksDataException {
+        return probeRFWriters[pid] == null ? null : probeRFWriters[pid].createReader();
+    }
+
+    /**
+     * Overrides the original method, but it does not close the File Reader that can be used latter.
+     *
+     * @param pid
+     * @param wr
+     * @return
+     * @throws HyracksDataException
+     */
+    protected boolean loadSpilledPartitionToMem(int pid, RunFileWriter wr) throws HyracksDataException {
+        RunFileReader r = wr.createReader();
+        r.open();
+        if (reloadBuffer == null) {
+            reloadBuffer = new VSizeFrame(jobletCtx);
+        }
+        while (r.nextFrame(reloadBuffer)) {
+            if (stats != null) {
+                //TODO: be certain it is the case this is actually eagerly read
+                stats.getBytesRead().update(reloadBuffer.getBuffer().limit());
+            }
+            accessorBuild.reset(reloadBuffer.getBuffer());
+            for (int tid = 0; tid < accessorBuild.getTupleCount(); tid++) {
+                if (!bufferManager.insertTuple(pid, accessorBuild, tid, tempPtr)) {
+                    // for some reason (e.g. fragmentation) if inserting fails, we need to clear the occupied frames
+                    bufferManager.clearPartition(pid);
+                    return false;
+                }
+            }
+        }
+        // Closes and deletes the run file if it is already loaded into memory.
+        spilledStatus.set(pid, false);
+        buildRFWriters[pid] = null;
+        return true;
+    }
+
+    /**
+     * Rebuild Hash Table, it throws away the original hashtable and builds a new one.
+     *
+     * @throws HyracksDataException
+     */
+    private void rebuildHashTable() throws HyracksDataException {
+        freeSpace fs = calculateFreeSpace();
+        table.close(); //This releases the frames used by the original Hash Table.
+        //Instantiates new hashtable considering the tuples reloaded from disk.
+        table = new SerializableHashTable(fs.tuplesInMemory, jobletCtx, bufferManagerForHashTable);
+        this.inMemJoiner = new InMemoryHashJoin(jobletCtx, new FrameTupleAccessor(probeRd), probeHpc,
+                new FrameTupleAccessor(buildRd), buildRd, buildHpc, isLeftOuter, nonMatchWriters, table, isReversed,
+                bufferManagerForHashTable);
+        inMemJoiner.setComparator(this.comparator);
+        bufferManager.setConstrain(VPartitionTupleBufferManager.NO_CONSTRAIN);
+        buildHashTable();
+        // Check if the Way I am calculating the free space is right?
+        // Size of the Hash Table should fit in my free space.
+        // Check the Actual Size of the Hash Table.
+        //
+    }
 
     @Override
+    public void initProbe(ITuplePairComparator comparator) {
+        this.comparator = comparator;
+        probePSizeInTups = new int[numOfPartitions];
+        inMemJoiner.setComparator(comparator);
+        bufferManager.setConstrain(VPartitionTupleBufferManager.NO_CONSTRAIN);
+    }
+
+    /**
+     * Override the original method, returning inconsistent and spilled partitions.
+     * Inconsistent partitions will be probed latter.
+     *
+     * @return
+     */
+    @Override
+    public BitSet getPartitionStatus() {
+        inconsistentStatus.or(spilledStatus);
+        return inconsistentStatus;
+    }
+
+
+    /**
+     * Complete Probe Phase
+     * If the Knobe ("probeInconsistentThisRound") is set as true the inconsistent partitions will be probed before completing this probe phase.
+     *
+     * @param writer
+     * @throws HyracksDataException
+     */
+    @Override
     public void completeProbe(IFrameWriter writer) throws HyracksDataException {
-        if(probeInconsistentThisRound){
+        if (probeInconsistentThisRound) {
             probeInconsistent(writer);
         }
         super.completeProbe(writer);
     }
 
-
+    /**
+     * Probe inconsistent partitions before completing the Probe Phase.
+     *
+     * @param writer Output File Writer
+     * @throws HyracksDataException
+     */
     private void probeInconsistent(IFrameWriter writer) throws HyracksDataException {
-        for(int i = inconsistentStatus.nextSetBit(0);i<numOfPartitions && i >= 0;i = inconsistentStatus.nextSetBit(i+1)){
-            if(spilledStatus.get(i)){
+        for (int i = inconsistentStatus.nextSetBit(0); i < numOfPartitions && i >= 0; i =
+                inconsistentStatus.nextSetBit(i + 1)) {
+            if (spilledStatus.get(i)) {
                 return;
             }
             RunFileReader reader = getProbeRFReader(i);
-            if(reader != null) {
+            if (reader != null) {
                 LOGGER.info(String.format("Partition %d is Inconsistent file has %d bytes", i, reader.getFileSize()));
                 reader.open();
-                while(reader.nextFrame(reloadBuffer)) {
+                while (reader.nextFrame(reloadBuffer)) {
                     accessorProbe.reset(reloadBuffer.getBuffer());
-                    LOGGER.info(String.format("Number of Tuples: %d", accessorProbe.getTupleCount()));
-                    probe(reloadBuffer.getBuffer(),writer);
+                    super.probe(reloadBuffer.getBuffer(), writer);
                 }
+                bufferManager.clearPartition(i);
+                reader.setDeleteAfterClose(true);
+                reader.close();
+                inconsistentStatus.clear(i);
             }
-
         }
-
+        LOGGER.info(String.format("Finished Probing inconsistent"));
     }
-    protected void closeAllSpilledPartitions(RunFileWriter[] runFileWriters, String refName) throws HyracksDataException {
+
+    //endregion
+    protected void closeAllSpilledPartitions(RunFileWriter[] runFileWriters, String refName)
+            throws HyracksDataException {
         spillRemaining(runFileWriters, refName);
     }
 }

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/MemoryContentionResponsiveHHJ.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/MemoryContentionResponsiveHHJ.java
@@ -254,15 +254,18 @@ public class MemoryContentionResponsiveHHJ extends OptimizedHybridHashJoin {
      * @param freeSpace     current free space
      * @param inMemTupCount number of tuples currently in memory
      * @return partition id of selected partition to reload
+     * @Todo Giulliano: Print what is the actual state in during the Event.
+     * Use Warn Logger Level.
+     *
      */
     protected int selectAPartitionToReloadProbe(long freeSpace, int inMemTupCount) {
         int frameSize = jobletCtx.getInitialFrameSize();
         // Add one frame to freeSpace to consider the one frame reserved for the spilled partition
-        long totalFreeSpace = freeSpace + frameSize;
+        long totalFreeSpace = freeSpace; //ToDo Giulliano: Check if it is working
         if (totalFreeSpace > 0) {
             for (int i = spilledStatus.nextSetBit(0); i >= 0 && i < numOfPartitions; i =
                     spilledStatus.nextSetBit(i + 1)) {
-                int spilledTupleCount = buildPSizeInTups[i];
+                int spilledTupleCount = buildPSizeInTups[i]; //Recalculate the number of Tuples based on the reloaded partition.
                 // Expected hash table size increase after reloading this partition
                 long originalHashTableSize = table.getCurrentByteSize();
                 totalFreeSpace += originalHashTableSize;

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/MemoryContentionResponsiveHHJ.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/MemoryContentionResponsiveHHJ.java
@@ -1,0 +1,86 @@
+package org.apache.hyracks.dataflow.std.join;
+
+import org.apache.hyracks.api.comm.IFrameWriter;
+import org.apache.hyracks.api.context.IHyracksJobletContext;
+import org.apache.hyracks.api.dataflow.value.IMissingWriterFactory;
+import org.apache.hyracks.api.dataflow.value.IPredicateEvaluator;
+import org.apache.hyracks.api.dataflow.value.ITuplePartitionComputer;
+import org.apache.hyracks.api.dataflow.value.RecordDescriptor;
+import org.apache.hyracks.api.exceptions.HyracksDataException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.Timer;
+import java.util.TimerTask;
+
+public class MemoryContentionResponsiveHHJ extends OptimizedHybridHashJoin {
+    private int processedFrames = 0;
+    private int frameInterval = 0;
+    private boolean eventBased = false;
+    private int timeInterval =0;
+    private Timer timer;
+
+    /**
+     * Timer Task to update Memory Budget when running on Time Strategy.
+     */
+    class UpdateMemoryTask extends TimerTask {
+        public void run() {
+            LOGGER.info("Update Memory Budget Based on TIME");
+            updateMemoryBudgetBuildPhase();
+        }
+    }
+
+    public MemoryContentionResponsiveHHJ(IHyracksJobletContext jobletCtx, int memSizeInFrames, int numOfPartitions, String probeRelName, String buildRelName, RecordDescriptor probeRd, RecordDescriptor buildRd, ITuplePartitionComputer probeHpc, ITuplePartitionComputer buildHpc, IPredicateEvaluator probePredEval, IPredicateEvaluator buildPredEval, boolean isLeftOuter, IMissingWriterFactory[] nullWriterFactories1,int timeInterval,int frameInterval,boolean eventBased) {
+        super(jobletCtx, memSizeInFrames, numOfPartitions, probeRelName, buildRelName, probeRd, buildRd, probeHpc, buildHpc, probePredEval, buildPredEval, isLeftOuter, nullWriterFactories1);
+        SetTimeInterval(timeInterval);
+        this.frameInterval = frameInterval;
+        this.eventBased = eventBased;
+    }
+
+    private void SetTimeInterval(int interval){
+        timeInterval = interval;
+        if(interval > 0) {
+            if (timer == null) {
+                timer = new Timer("Update Budget");
+            } else {
+                timer.cancel();
+            }
+            timer.schedule(new UpdateMemoryTask(), 0, timeInterval);
+        }
+        else if(timer != null){
+            timer.cancel();
+        }
+    }
+
+    public void build(ByteBuffer buffer)  throws HyracksDataException {
+        if(frameInterval > 0 && processedFrames % frameInterval == 0){
+            LOGGER.info("Update Memory Budget Based on FRAME");
+            updateMemoryBudgetBuildPhase();
+        }
+        super.build(buffer);
+        processedFrames++;
+    }
+
+    /**
+     * Updates Memory Budget During Build Phase
+     */
+    private void updateMemoryBudgetBuildPhase(){
+        int newBudget = new Random().nextInt(2*memSizeInFrames)+ this.memSizeInFrames;
+    }
+
+    @Override
+    public void spillPartition(int pid) throws HyracksDataException {
+        if(eventBased){
+            LOGGER.info("Update Memory Budget Based on EVENT");
+            updateMemoryBudgetBuildPhase();
+        }
+        super.spillPartition(pid);
+    }
+    @Override
+    public void completeProbe(IFrameWriter writer) throws HyracksDataException {
+        super.completeProbe(writer);
+        LOGGER.info("Complete HHJ Round");
+        if(timer != null) {
+            timer.cancel();
+        }
+    }
+}

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoin.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoin.java
@@ -89,7 +89,7 @@ public class OptimizedHybridHashJoin implements IOptimizedHybridHashJoin {
     // Added for handling correct calling for predicate-evaluator upon recursive calls that cause role-reversal.
     protected boolean isReversed;
     // stats information
-    private int[] buildPSizeInTups;
+    protected int[] buildPSizeInTups;
     protected IFrame reloadBuffer;
     // this is a reusable object to store the pointer,which is not used anywhere. we mainly use it to match the
     // corresponding function signature.
@@ -134,7 +134,7 @@ public class OptimizedHybridHashJoin implements IOptimizedHybridHashJoin {
     @Override
     public void initBuild() throws HyracksDataException {
         IDeallocatableFramePool framePool =
-            new DeallocatableFramePool(jobletCtx, memSizeInFrames * jobletCtx.getInitialFrameSize());
+                new DeallocatableFramePool(jobletCtx, memSizeInFrames * jobletCtx.getInitialFrameSize());
         initBuildInternal(framePool);
     }
 
@@ -162,8 +162,8 @@ public class OptimizedHybridHashJoin implements IOptimizedHybridHashJoin {
         }
     }
 
-    protected void processTupleBuildPhase(int tid, int pid) throws HyracksDataException{
-        processTupleBuildPhaseInternal(tid,pid);
+    protected void processTupleBuildPhase(int tid, int pid) throws HyracksDataException {
+        processTupleBuildPhaseInternal(tid, pid);
     }
 
     protected void processTupleBuildPhaseInternal(int tid, int pid) throws HyracksDataException {
@@ -282,9 +282,10 @@ public class OptimizedHybridHashJoin implements IOptimizedHybridHashJoin {
         }
     }
 
-    protected void closeAllSpilledPartitions(RunFileWriter[] runFileWriters, String refName) throws HyracksDataException {
+    protected void closeAllSpilledPartitions(RunFileWriter[] runFileWriters, String refName)
+            throws HyracksDataException {
         try {
-            spillRemaining(runFileWriters,refName);
+            spillRemaining(runFileWriters, refName);
         } finally {
             // Force to close all run file writers.
             closeFileWriters(runFileWriters);
@@ -320,7 +321,6 @@ public class OptimizedHybridHashJoin implements IOptimizedHybridHashJoin {
         }
     }
 
-
     /**
      * Makes the space for the hash table. If there is no enough space, one or more partitions will be spilled
      * to the disk until the hash table can fit into the memory. After this, bring back spilled partitions
@@ -331,15 +331,16 @@ public class OptimizedHybridHashJoin implements IOptimizedHybridHashJoin {
      */
     protected int makeSpaceForHashTableAndBringBackSpilledPartitions() throws HyracksDataException {
         freeSpace fs = calculateFreeSpace();
-        return spillAndReloadPartitions(jobletCtx.getInitialFrameSize(),fs.freeSpace , fs.tuplesInMemory);
+        return spillAndReloadPartitions(jobletCtx.getInitialFrameSize(), fs.freeSpace, fs.tuplesInMemory);
     }
 
-    protected class freeSpace{
+    protected class freeSpace {
         long freeSpace;
         int tuplesInMemory;
-        public freeSpace(long freeSpace, int tuplesInMemory){
-           this.freeSpace = freeSpace;
-           this.tuplesInMemory = tuplesInMemory;
+
+        public freeSpace(long freeSpace, int tuplesInMemory) {
+            this.freeSpace = freeSpace;
+            this.tuplesInMemory = tuplesInMemory;
         }
     }
 
@@ -348,7 +349,7 @@ public class OptimizedHybridHashJoin implements IOptimizedHybridHashJoin {
      * Total Memory - Memory Resident Partitions - Hash Table.
      * @return
      */
-    protected freeSpace calculateFreeSpace(){
+    protected freeSpace calculateFreeSpace() {
         int frameSize = jobletCtx.getInitialFrameSize();
         long freeSpace = (long) (memSizeInFrames - spilledStatus.cardinality()) * frameSize;
         int inMemTupCount = 0;
@@ -358,9 +359,8 @@ public class OptimizedHybridHashJoin implements IOptimizedHybridHashJoin {
             inMemTupCount += buildPSizeInTups[p];
         }
         freeSpace -= SerializableHashTable.getExpectedTableByteSize(inMemTupCount, frameSize);
-        return new freeSpace(freeSpace,inMemTupCount);
+        return new freeSpace(freeSpace, inMemTupCount);
     }
-
 
     /**
      * Spill Partitions if there is no Free Space for the Hash Table
@@ -370,7 +370,8 @@ public class OptimizedHybridHashJoin implements IOptimizedHybridHashJoin {
      * @return
      * @throws HyracksDataException
      */
-    protected int spillAndReloadPartitions(int frameSize, long freeSpace, int inMemTupCount) throws HyracksDataException {
+    protected int spillAndReloadPartitions(int frameSize, long freeSpace, int inMemTupCount)
+            throws HyracksDataException {
         int pidToSpill, numberOfTuplesToBeSpilled;
         long expectedHashTableSizeDecrease;
         long currentFreeSpace = freeSpace;
@@ -578,7 +579,7 @@ public class OptimizedHybridHashJoin implements IOptimizedHybridHashJoin {
 
     private void processTupleProbePhase(int tupleId, int pid) throws HyracksDataException {
         if (!bufferManager.insertTuple(pid, accessorProbe, tupleId, tempPtr)) {
-                int recordSize =
+            int recordSize =
                     VPartitionTupleBufferManager.calculateActualSize(null, accessorProbe.getTupleLength(tupleId));
             // If the partition is at least half-full and insertion fails, that partition is preferred to get
             // spilled, otherwise the biggest partition gets chosen as the victim.
@@ -716,6 +717,7 @@ public class OptimizedHybridHashJoin implements IOptimizedHybridHashJoin {
         LOGGER.debug("can't insert tuple in join memory. {}", details);
         LOGGER.debug("partitions status:\n{}", spillPolicy.partitionsStatus());
     }
+
     @Override
     public void setOperatorStats(IOperatorStats stats) {
         this.stats = stats;

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoinOperatorDescriptor.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoinOperatorDescriptor.java
@@ -615,8 +615,8 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
                     assert isLeftOuter ? !isReversed : true : "LeftOut Join can not reverse roles";
                     OptimizedHybridHashJoin rHHj;
                     int n = getNumberOfPartitions(state.memForJoin, tableSize, fudgeFactor, nPartitions);
-                    rHHj = new MemoryContentionResponsiveHHJ(jobletCtx, state.memForJoin, n, PROBE_REL, BUILD_REL, probeRd,
-                            buildRd, probeHpc, buildHpc, null, null, isLeftOuter, nonMatchWriterFactories); //checked-confirmed
+                    rHHj = new MemoryContentionResponsiveHHJ(jobletCtx, state.memForJoin, n, PROBE_REL, BUILD_REL,
+                            probeRd, buildRd, probeHpc, buildHpc, null, null, isLeftOuter, nonMatchWriterFactories); //checked-confirmed
 
                     rHHj.setIsReversed(isReversed);
                     try {

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoinOperatorDescriptor.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoinOperatorDescriptor.java
@@ -145,8 +145,6 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
     private boolean forceRoleReversal = false;
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int frameInterval = 10;
-    private  boolean eventBased = false;
 
     public OptimizedHybridHashJoinOperatorDescriptor(IOperatorDescriptorRegistry spec, int memSizeInFrames,
             int inputsize0, double factor, int[] keys0, int[] keys1,
@@ -232,7 +230,7 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
 
         private int memForJoin;
         private int numOfPartitions;
-        private IOptimizedHybridHashJoin hybridHJ;
+        private OptimizedHybridHashJoin hybridHJ;
 
         public BuildAndPartitionTaskState() {
         }
@@ -304,7 +302,7 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
                             getNumberOfPartitions(state.memForJoin, inputsize0, fudgeFactor, nPartitions);
                     state.hybridHJ = new MemoryContentionResponsiveHHJ(ctx.getJobletContext(), state.memForJoin,
                             state.numOfPartitions, PROBE_REL, BUILD_REL, probeRd, buildRd, probeHpc, buildHpc,
-                            probePredEval, buildPredEval, isLeftOuter, nonMatchWriterFactories,frameInterval,eventBased);
+                            probePredEval, buildPredEval, isLeftOuter, nonMatchWriterFactories);
                     state.hybridHJ.setOperatorStats(stats);
 
                     state.hybridHJ.initBuild();
@@ -615,10 +613,10 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
                     boolean isReversed = probeKeys == OptimizedHybridHashJoinOperatorDescriptor.this.buildKeys
                             && buildKeys == OptimizedHybridHashJoinOperatorDescriptor.this.probeKeys;
                     assert isLeftOuter ? !isReversed : true : "LeftOut Join can not reverse roles";
-                    IOptimizedHybridHashJoin rHHj;
+                    OptimizedHybridHashJoin rHHj;
                     int n = getNumberOfPartitions(state.memForJoin, tableSize, fudgeFactor, nPartitions);
                     rHHj = new MemoryContentionResponsiveHHJ(jobletCtx, state.memForJoin, n, PROBE_REL, BUILD_REL, probeRd,
-                            buildRd, probeHpc, buildHpc, null, null, isLeftOuter, nonMatchWriterFactories,frameInterval,eventBased); //checked-confirmed
+                            buildRd, probeHpc, buildHpc, null, null, isLeftOuter, nonMatchWriterFactories); //checked-confirmed
 
                     rHHj.setIsReversed(isReversed);
                     try {

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoinOperatorDescriptor.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoinOperatorDescriptor.java
@@ -145,8 +145,7 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
     private boolean forceRoleReversal = false;
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int timeInterval = 100;
-    private int frameInterval = 10;
+    private int frameInterval = 0;
     private  boolean eventBased = false;
 
     public OptimizedHybridHashJoinOperatorDescriptor(IOperatorDescriptorRegistry spec, int memSizeInFrames,

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoinOperatorDescriptor.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoinOperatorDescriptor.java
@@ -145,7 +145,7 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
     private boolean forceRoleReversal = false;
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int frameInterval = 0;
+    private int frameInterval = 10;
     private  boolean eventBased = false;
 
     public OptimizedHybridHashJoinOperatorDescriptor(IOperatorDescriptorRegistry spec, int memSizeInFrames,
@@ -304,7 +304,7 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
                             getNumberOfPartitions(state.memForJoin, inputsize0, fudgeFactor, nPartitions);
                     state.hybridHJ = new MemoryContentionResponsiveHHJ(ctx.getJobletContext(), state.memForJoin,
                             state.numOfPartitions, PROBE_REL, BUILD_REL, probeRd, buildRd, probeHpc, buildHpc,
-                            probePredEval, buildPredEval, isLeftOuter, nonMatchWriterFactories,timeInterval,frameInterval,eventBased);
+                            probePredEval, buildPredEval, isLeftOuter, nonMatchWriterFactories,frameInterval,eventBased);
                     state.hybridHJ.setOperatorStats(stats);
 
                     state.hybridHJ.initBuild();
@@ -618,7 +618,7 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
                     IOptimizedHybridHashJoin rHHj;
                     int n = getNumberOfPartitions(state.memForJoin, tableSize, fudgeFactor, nPartitions);
                     rHHj = new MemoryContentionResponsiveHHJ(jobletCtx, state.memForJoin, n, PROBE_REL, BUILD_REL, probeRd,
-                            buildRd, probeHpc, buildHpc, null, null, isLeftOuter, nonMatchWriterFactories,timeInterval,frameInterval,eventBased); //checked-confirmed
+                            buildRd, probeHpc, buildHpc, null, null, isLeftOuter, nonMatchWriterFactories,frameInterval,eventBased); //checked-confirmed
 
                     rHHj.setIsReversed(isReversed);
                     try {


### PR DESCRIPTION


Working version, still getting some errors in calculating the free space before reloading partitions after a memory expansion during the PROBE Phase.

Data Used to test:
4 data partitions were built using Winsconsin Data Generator.

Queries Used to test:
Simple Join filtering the [100, 1000, 5000, 20000, 50000] entries selecting only {W1.unique1, W2.unique1} fields.
Simple Join filtering the [100, 1000] entries selecting all fields.

3-Way Join filtering the [100, 1000, 5000, 20000, 50000] entries selecting only {W1.unique1, W2.unique1,W3.unique1} fields.
3-Way Join filtering the [100, 1000] entries selecting all fields.

4-Way Join filtering the [100, 1000, 5000, 20000, 50000] entries selecting only {{W1.unique1, W2.unique1,W3.unique1,W4.unique1} fields.
4-Way Join filtering the [100, 1000] entries selecting all fields.

#LOG BEFORE ERROR:
Screenshot from 2023-07-16 11-51-38

Note the last line, the "FREE SPACE" is smaller the sum of "HASH TABLE" and "PARTITION"

I tried creating a new method to Calculate the Free space using the actual size of the HASH TABLE, but got the same error.
